### PR TITLE
Do not require release test dependencies

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,10 +22,7 @@ my %script_prereq = (
 );
 
 my %test_prereq = (
-   'File::Find::Rule'         => '0',
    'Test::More'               => '0',
-   'Test::Pod'                => '1.00',
-   'Test::Pod::Coverage'      => '1.00',
 );
 
 my %config_prereq = (

--- a/t/_pod.t
+++ b/t/_pod.t
@@ -3,15 +3,18 @@
 use warnings 'all';
 use strict;
 use Test::More;
+
+BEGIN {
+    # Don't run tests for installs
+    unless ($ENV{RELEASE_TESTING}) {
+       plan skip_all => 'Author tests not required for installation (set RELEASE_TESTING to test)';
+    }
+}
+
 use File::Basename;
 use Cwd 'abs_path';
 use Test::Pod 1.00;
 
-# Don't run tests for installs
-unless ($ENV{RELEASE_TESTING}) {
-   plan skip_all => 'Author tests not required for installation (set RELEASE_TESTING to test)';
-}
-  
 # Figure out the directories.  This comes from Test::Inter.
 
 my($moddir,$testdir,$libdir);

--- a/t/_pod_coverage.t
+++ b/t/_pod_coverage.t
@@ -3,14 +3,17 @@
 use warnings 'all';
 use strict;
 use Test::More;
+
+BEGIN {
+    # Don't run tests for installs
+    unless ($ENV{RELEASE_TESTING}) {
+       plan skip_all => 'Author tests not required for installation (set RELEASE_TESTING to test)';
+    }
+}
+
 use File::Basename;
 use Cwd 'abs_path';
 use Test::Pod::Coverage 1.00;
-
-# Don't run tests for installs
-unless ($ENV{RELEASE_TESTING}) {
-   plan skip_all => 'Author tests not required for installation (set RELEASE_TESTING to test)';
-}
 
 # Figure out the directories.  This comes from Test::Inter.
 

--- a/t/_version.t
+++ b/t/_version.t
@@ -3,13 +3,17 @@
 use warnings 'all';
 use strict;
 use Test::Inter;
+
+my $ti;
+BEGIN {
+    $ti      = new Test::Inter $0;
+    unless ($ENV{RELEASE_TESTING}) {
+       $ti->skip_all('Author tests not required for installation (set RELEASE_TESTING to test)');
+    }
+}
+
 use IO::File;
 use File::Find::Rule;
-my $ti      = new Test::Inter $0;
-
-unless ($ENV{RELEASE_TESTING}) {
-   $ti->skip_all('Author tests not required for installation (set RELEASE_TESTING to test)');
-}
 
 # Figure out what module we are in.  A module is in a directory:
 #    My-Mod-Name-1.00


### PR DESCRIPTION
By default release tests are skipped. However, the tests have some
uniq additional dependencies. Terminating the tests before loading the
dependencies enables us dropping a dependency on them.